### PR TITLE
Bump PHP CS Fixer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM php:8.0.1-alpine
+FROM --platform=linux/amd64 php:8.1-alpine
 
 LABEL "com.github.actions.name"="PHP-CS-Fixer"
 LABEL "com.github.actions.description"="check php files"
 LABEL "com.github.actions.icon"="check"
 LABEL "com.github.actions.color"="blue"
 
-RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.3/php-cs-fixer.phar -O php-cs-fixer \
+RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.13.0/php-cs-fixer.phar -O php-cs-fixer \
     && chmod a+x php-cs-fixer \
     && mv php-cs-fixer /usr/local/bin/php-cs-fixer
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,5 @@ version: '3.8'
 services:
   php-cs-fixer:
     build: .
-    image: public.ecr.aws/u9q7y3l4/github-actions-php-cs-fixer
+    image: public.ecr.aws/u9q7y3l4/github-actions-php-cs-fixer:v3.13.0
 


### PR DESCRIPTION
### What does it do? Why?

- Bump to a recent version (v3.13.0) compatible with php8.1
- Ajout d'un tag de version sur ECR pour pouvoir utiliser une version ou l'autre pendant la transition php7 vers php8 et de toute façon c'est plus explicite d'utiliser un numéro de version (la PR côté mobsuccess https://github.com/mobsuccess-devops/mobsuccess/pull/1649)
- Force le build sur `--platform=linux/amd64` (quand on est sur mac)